### PR TITLE
Fix 'tblite guess --method ceh' for AC's and simplify code

### DIFF
--- a/app/driver_guess.f90
+++ b/app/driver_guess.f90
@@ -16,7 +16,7 @@
 
 !> Implementation of the driver entry points for the singlepoint runner
 module tblite_driver_guess
-   use, intrinsic :: iso_fortran_env, only : output_unit, error_unit, input_unit
+   use, intrinsic :: iso_fortran_env, only : error_unit, input_unit
    use mctc_env, only : error_type, fatal_error, wp
    use mctc_io, only : structure_type, read_structure, filetype
    use mctc_io_constants, only : codata
@@ -29,10 +29,8 @@ module tblite_driver_guess
    use tblite_lapack_solver, only : lapack_solver
    use tblite_output_ascii
    use tblite_wavefunction, only : wavefunction_type, new_wavefunction, &
-   & sad_guess, eeq_guess, get_molecular_dipole_moment, get_molecular_quadrupole_moment, &
-   & shell_partition
-   use tblite_xtb_calculator, only : xtb_calculator, new_xtb_calculator
-   use tblite_xtb_gfn2, only : new_gfn2_calculator
+   & sad_guess, eeq_guess, get_molecular_dipole_moment
+   use tblite_xtb_calculator, only : xtb_calculator
    use tblite_ceh_singlepoint, only : ceh_singlepoint
    use tblite_ceh_ceh, only : new_ceh_calculator
 

--- a/app/driver_run.f90
+++ b/app/driver_run.f90
@@ -40,7 +40,7 @@ module tblite_driver_run
    use tblite_xtb_gfn1, only : new_gfn1_calculator, export_gfn1_param
    use tblite_xtb_ipea1, only : new_ipea1_calculator, export_ipea1_param
    use tblite_xtb_singlepoint, only : xtb_singlepoint
-   use tblite_ceh_singlepoint, only : ceh_guess
+   use tblite_ceh_singlepoint, only : ceh_singlepoint
    use tblite_ceh_ceh, only : new_ceh_calculator
    use tblite_post_processing_list, only : add_post_processing, post_processing_type, post_processing_list
 
@@ -142,11 +142,11 @@ subroutine run_main(config, error)
       case default
          call fatal_error(error, "Unknown method '"//method//"' requested")
       case("gfn2")
-         call new_gfn2_calculator(calc, mol)
+         call new_gfn2_calculator(calc, mol, error)
       case("gfn1")
-         call new_gfn1_calculator(calc, mol)
+         call new_gfn1_calculator(calc, mol, error)
       case("ipea1")
-         call new_ipea1_calculator(calc, mol)
+         call new_ipea1_calculator(calc, mol, error)
       end select
    end if
    if (allocated(error)) return
@@ -156,13 +156,14 @@ subroutine run_main(config, error)
    call new_wavefunction(wfn, mol%nat, calc%bas%nsh, calc%bas%nao, nspin, config%etemp * kt)
 
    if (config%guess == "ceh") then
-      call new_ceh_calculator(calc_ceh, mol)
+      call new_ceh_calculator(calc_ceh, mol, error)
       call new_wavefunction(wfn_ceh, mol%nat, calc_ceh%bas%nsh, calc_ceh%bas%nao, 1, config%etemp_guess * kt)
       if (config%grad) then
          call ctx%message("WARNING: CEH gradient not yet implemented. Stopping.")
          return
       end if
    end if
+   if (allocated(error)) return
 
    if (allocated(config%efield)) then
       block
@@ -187,7 +188,7 @@ subroutine run_main(config, error)
    case("eeq")
       call eeq_guess(mol, calc, wfn)
    case("ceh")
-      call ceh_guess(ctx, calc_ceh, mol, error, wfn_ceh, config%accuracy, config%verbosity)
+      call ceh_singlepoint(ctx, calc_ceh, mol, error, wfn_ceh, config%accuracy, config%verbosity)
       if (ctx%failed()) then
          call fatal(ctx, "CEH singlepoint calculation failed")
          do while(ctx%failed())

--- a/src/tblite/api/calculator.f90
+++ b/src/tblite/api/calculator.f90
@@ -88,6 +88,7 @@ function new_gfn2_calculator_api(vctx, vmol) result(vcalc) &
    type(vp_structure), pointer :: mol
    type(c_ptr) :: vcalc
    type(vp_calculator), pointer :: calc
+   type(error_type), allocatable :: error
 
    if (debug) print '("[Info]", 1x, a)', "new_gfn2_calculator"
 
@@ -99,8 +100,12 @@ function new_gfn2_calculator_api(vctx, vmol) result(vcalc) &
    call c_f_pointer(vmol, mol)
 
    allocate(calc)
-   call new_gfn2_calculator(calc%ptr, mol%ptr)
-   vcalc = c_loc(calc)
+   call new_gfn2_calculator(calc%ptr, mol%ptr, error)
+   if (allocated(error)) then
+      deallocate(calc)
+   else
+      vcalc = c_loc(calc)
+   end if
 
 end function new_gfn2_calculator_api
 
@@ -113,6 +118,7 @@ function new_ipea1_calculator_api(vctx, vmol) result(vcalc) &
    type(vp_structure), pointer :: mol
    type(c_ptr) :: vcalc
    type(vp_calculator), pointer :: calc
+   type(error_type), allocatable :: error
 
    if (debug) print '("[Info]", 1x, a)', "new_ipea1_calculator"
 
@@ -124,8 +130,12 @@ function new_ipea1_calculator_api(vctx, vmol) result(vcalc) &
    call c_f_pointer(vmol, mol)
 
    allocate(calc)
-   call new_ipea1_calculator(calc%ptr, mol%ptr)
-   vcalc = c_loc(calc)
+   call new_ipea1_calculator(calc%ptr, mol%ptr, error)
+   if (allocated(error)) then
+      deallocate(calc)
+   else
+      vcalc = c_loc(calc)
+   end if
 
 end function new_ipea1_calculator_api
 
@@ -138,6 +148,7 @@ function new_gfn1_calculator_api(vctx, vmol) result(vcalc) &
    type(vp_structure), pointer :: mol
    type(c_ptr) :: vcalc
    type(vp_calculator), pointer :: calc
+   type(error_type), allocatable :: error
 
    if (debug) print '("[Info]", 1x, a)', "new_gfn1_calculator"
 
@@ -149,8 +160,12 @@ function new_gfn1_calculator_api(vctx, vmol) result(vcalc) &
    call c_f_pointer(vmol, mol)
 
    allocate(calc)
-   call new_gfn1_calculator(calc%ptr, mol%ptr)
-   vcalc = c_loc(calc)
+   call new_gfn1_calculator(calc%ptr, mol%ptr, error)
+   if (allocated(error)) then
+      deallocate(calc)
+   else
+      vcalc = c_loc(calc)
+   end if
 
 end function new_gfn1_calculator_api
 

--- a/src/tblite/ceh/ceh.f90
+++ b/src/tblite/ceh/ceh.f90
@@ -18,7 +18,7 @@
 !> Contains the specification of the Charge Extended Hückel (CEH) method.
 
 module tblite_ceh_ceh
-   use mctc_env, only : error_type, wp
+   use mctc_env, only : wp, error_type, fatal_error
    use mctc_io, only: structure_type
    use tblite_basis_ortho, only : orthogonalize
    use tblite_basis_slater, only : slater_to_gauss
@@ -910,10 +910,21 @@ module tblite_ceh_ceh
 contains
 
 
-   subroutine new_ceh_calculator(calc,mol)
+   subroutine new_ceh_calculator(calc, mol, error)
       !> Instance of the CEH evaluator
       type(xtb_calculator), intent(out) :: calc
       type(structure_type), intent(in)  :: mol
+      !> Error handling
+      type(error_type), allocatable, intent(out) :: error
+      !> String out of max_elem
+      character(len=3) :: max_elem_str
+
+      write(max_elem_str, '(I3)') max_elem
+      !> Check if all atoms of mol%nat are supported (Z <= 86)
+      if (any(mol%num > max_elem)) then
+         call fatal_error(error, "No support for elements with Z >" // max_elem_str // ".")
+         return
+      end if
 
       call add_ceh_basis(calc, mol)
       call add_ncoord(calc, mol)

--- a/src/tblite/ceh/singlepoint.f90
+++ b/src/tblite/ceh/singlepoint.f90
@@ -46,7 +46,7 @@ module tblite_ceh_singlepoint
    implicit none
    private
 
-   public :: ceh_guess
+   public :: ceh_singlepoint
 
    real(wp), parameter :: cn_cutoff = 25.0_wp
 
@@ -61,7 +61,7 @@ contains
 
 
    !> Run the CEH calculation (equivalent to xtb_singlepoint)
-   subroutine ceh_guess(ctx, calc, mol, error, wfn, accuracy, verbosity)
+   subroutine ceh_singlepoint(ctx, calc, mol, error, wfn, accuracy, verbosity)
       !> Calculation context
       type(context_type), intent(inout) :: ctx
       !> CEH calculator
@@ -215,6 +215,6 @@ contains
       call timer%pop
       ttime = timer%get("wall time CEH")
 
-   end subroutine ceh_guess
+   end subroutine ceh_singlepoint
    
 end module tblite_ceh_singlepoint

--- a/src/tblite/wavefunction/guess.f90
+++ b/src/tblite/wavefunction/guess.f90
@@ -19,7 +19,7 @@
 
 !> Implementation of the guess wavefunctions
 module tblite_wavefunction_guess
-   use mctc_env, only : wp, error_type, fatal_error
+   use mctc_env, only : wp, error_type
    use mctc_io, only : structure_type
    use tblite_disp_d4, only : get_eeq_charges
    use tblite_wavefunction_type, only : wavefunction_type

--- a/src/tblite/wavefunction/guess.f90
+++ b/src/tblite/wavefunction/guess.f90
@@ -48,7 +48,6 @@ subroutine sad_guess_qat(mol, charges, dpat)
    real(wp), intent(inout) :: charges(:), dpat(:, :)
 
    dpat = 0.0_wp
-   charges = 0.0_wp
    charges = mol%charge / mol%nat
 end subroutine sad_guess_qat
 
@@ -66,7 +65,6 @@ subroutine eeq_guess_qat(mol, charges, dpat)
    real(wp), intent(inout) :: charges(:), dpat(:, :)
 
    dpat = 0.0_wp
-   charges = 0.0_wp
    call get_eeq_charges(mol, charges)
 end subroutine eeq_guess_qat
 

--- a/src/tblite/wavefunction/guess.f90
+++ b/src/tblite/wavefunction/guess.f90
@@ -19,14 +19,12 @@
 
 !> Implementation of the guess wavefunctions
 module tblite_wavefunction_guess
-   use, intrinsic :: iso_fortran_env, only : error_unit
    use mctc_env, only : wp, error_type, fatal_error
    use mctc_io, only : structure_type
    use tblite_disp_d4, only : get_eeq_charges
    use tblite_wavefunction_type, only : wavefunction_type
    use tblite_xtb_h0, only : get_occupation
    use tblite_xtb_calculator, only : xtb_calculator
-   use tblite_context, only : context_type
    implicit none
    private
 

--- a/src/tblite/wavefunction/guess.f90
+++ b/src/tblite/wavefunction/guess.f90
@@ -19,38 +19,65 @@
 
 !> Implementation of the guess wavefunctions
 module tblite_wavefunction_guess
-   use mctc_env, only : wp
+   use, intrinsic :: iso_fortran_env, only : error_unit
+   use mctc_env, only : wp, error_type, fatal_error
    use mctc_io, only : structure_type
    use tblite_disp_d4, only : get_eeq_charges
    use tblite_wavefunction_type, only : wavefunction_type
    use tblite_xtb_h0, only : get_occupation
    use tblite_xtb_calculator, only : xtb_calculator
+   use tblite_context, only : context_type
    implicit none
    private
 
    public :: sad_guess, eeq_guess, shell_partition
+   interface sad_guess
+      module procedure sad_guess_qat
+      module procedure sad_guess_qsh
+   end interface sad_guess
+
+   interface eeq_guess
+      module procedure eeq_guess_qat
+      module procedure eeq_guess_qsh
+   end interface eeq_guess
 
 contains
 
-subroutine sad_guess(mol, calc, wfn)
+subroutine sad_guess_qat(mol, charges, dpat)
+   type(structure_type), intent(in) :: mol
+   real(wp), intent(inout) :: charges(:), dpat(:, :)
+
+   dpat = 0.0_wp
+   charges = 0.0_wp
+   charges = mol%charge / mol%nat
+end subroutine sad_guess_qat
+
+subroutine sad_guess_qsh(mol, calc, wfn)
    type(structure_type), intent(in) :: mol
    type(xtb_calculator), intent(in) :: calc
    type(wavefunction_type), intent(inout) :: wfn
 
-   wfn%qat(:, :) = 0.0_wp
-   wfn%qat(:, 1) = mol%charge / mol%nat
+   call sad_guess_qat(mol, wfn%qat(:, 1), wfn%dpat(:, :, 1))
    call shell_partition(mol, calc, wfn)
-end subroutine sad_guess
+end subroutine sad_guess_qsh
 
-subroutine eeq_guess(mol, calc, wfn)
+subroutine eeq_guess_qat(mol, charges, dpat)
+   type(structure_type), intent(in) :: mol
+   real(wp), intent(inout) :: charges(:), dpat(:, :)
+
+   dpat = 0.0_wp
+   charges = 0.0_wp
+   call get_eeq_charges(mol, charges)
+end subroutine eeq_guess_qat
+
+subroutine eeq_guess_qsh(mol, calc, wfn)
    type(structure_type), intent(in) :: mol
    type(xtb_calculator), intent(in) :: calc
    type(wavefunction_type), intent(inout) :: wfn
 
-   wfn%qat(:, :) = 0.0_wp
-   call get_eeq_charges(mol, wfn%qat(:, 1))
+   call eeq_guess_qat(mol, wfn%qat(:, 1), wfn%dpat(:, :, 1))
    call shell_partition(mol, calc, wfn)
-end subroutine eeq_guess
+end subroutine eeq_guess_qsh
 
 subroutine shell_partition(mol, calc, wfn)
    type(structure_type), intent(in) :: mol

--- a/src/tblite/xtb/gfn1.f90
+++ b/src/tblite/xtb/gfn1.f90
@@ -19,7 +19,7 @@
 
 !> Implementation of the GFN1-xTB Hamiltonian to parametrize an xTB calculator.
 module tblite_xtb_gfn1
-   use mctc_env, only : wp
+   use mctc_env, only : wp, error_type, fatal_error
    use mctc_io, only : structure_type
    use mctc_io_symbols, only : to_symbol
    use tblite_basis_ortho, only : orthogonalize
@@ -515,12 +515,22 @@ module tblite_xtb_gfn1
 contains
 
 
-subroutine new_gfn1_calculator(calc, mol)
+subroutine new_gfn1_calculator(calc, mol, error)
    !> Instance of the xTB evaluator
    type(xtb_calculator), intent(out) :: calc
    !> Molecular structure data
    type(structure_type), intent(in) :: mol
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+   !> String out of max_elem
+   character(len=3) :: max_elem_str
 
+   write(max_elem_str, '(I3)') max_elem
+   !> Check if all atoms of mol%nat are supported (Z <= 86)
+   if (any(mol%num > max_elem)) then
+      call fatal_error(error, "No support for elements with Z >" // max_elem_str // ".")
+      return
+   end if
    call add_basis(calc, mol)
    call add_ncoord(calc, mol)
    call add_hamiltonian(calc, mol)

--- a/src/tblite/xtb/gfn2.f90
+++ b/src/tblite/xtb/gfn2.f90
@@ -19,7 +19,7 @@
 
 !> Implementation of the GFN2-xTB Hamiltonian to parametrize an xTB calculator.
 module tblite_xtb_gfn2
-   use mctc_env, only : wp
+   use mctc_env, only : wp, error_type, fatal_error
    use mctc_io, only : structure_type
    use mctc_io_symbols, only : to_symbol
    use tblite_basis_type, only : basis_type, new_basis, cgto_type
@@ -566,12 +566,22 @@ module tblite_xtb_gfn2
 contains
 
 
-subroutine new_gfn2_calculator(calc, mol)
+subroutine new_gfn2_calculator(calc, mol, error)
    !> Instance of the xTB evaluator
    type(xtb_calculator), intent(out) :: calc
    !> Molecular structure data
    type(structure_type), intent(in) :: mol
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+   !> String out of max_elem
+   character(len=3) :: max_elem_str
 
+   write(max_elem_str, '(I3)') max_elem
+   !> Check if all atoms of mol%nat are supported (Z <= 86)
+   if (any(mol%num > max_elem)) then
+      call fatal_error(error, "No support for elements with Z >" // max_elem_str // ".")
+      return
+   end if
    call add_basis(calc, mol)
    call add_ncoord(calc, mol)
    call add_hamiltonian(calc, mol)

--- a/src/tblite/xtb/ipea1.f90
+++ b/src/tblite/xtb/ipea1.f90
@@ -19,7 +19,7 @@
 
 !> Implementation of the IPEA1-xTB Hamiltonian to parametrize an xTB calculator.
 module tblite_xtb_ipea1
-   use mctc_env, only : wp
+   use mctc_env, only : wp, error_type, fatal_error
    use mctc_io, only : structure_type
    use mctc_io_symbols, only : to_symbol
    use tblite_basis_ortho, only : orthogonalize
@@ -525,11 +525,22 @@ module tblite_xtb_ipea1
 contains
 
 
-subroutine new_ipea1_calculator(calc, mol)
+subroutine new_ipea1_calculator(calc, mol, error)
    !> Instance of the xTB evaluator
    type(xtb_calculator), intent(out) :: calc
    !> Molecular structure data
    type(structure_type), intent(in) :: mol
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+   !> String out of max_elem
+   character(len=3) :: max_elem_str
+
+   write(max_elem_str, '(I3)') max_elem
+   !> Check if all atoms of mol%nat are supported (Z <= 86)
+   if (any(mol%num > max_elem)) then
+      call fatal_error(error, "No support for elements with Z >" // max_elem_str // ".")
+      return
+   end if
 
    call add_basis(calc, mol)
    call add_ncoord(calc, mol)

--- a/test/unit/test_ceh.f90
+++ b/test/unit/test_ceh.f90
@@ -35,7 +35,7 @@ module test_ceh
 
    use tblite_wavefunction_type, only : wavefunction_type, new_wavefunction
    use tblite_xtb_calculator, only : xtb_calculator
-   use tblite_ceh_singlepoint, only : ceh_guess
+   use tblite_ceh_singlepoint, only : ceh_singlepoint
    use tblite_ceh_ceh, only : ceh_h0spec, new_ceh_calculator
    use tblite_ceh_h0, only : get_scaled_selfenergy, get_hamiltonian
 
@@ -471,10 +471,10 @@ contains
       integer :: i
       allocate(cn(mol%nat))
 
-      call new_ceh_calculator(calc, mol)
+      call new_ceh_calculator(calc, mol, error)
       call new_wavefunction(wfn, mol%nat, calc%bas%nsh, calc%bas%nao, 1, kt)
       ctx%verbosity = 0
-      call ceh_guess(ctx, calc, mol, error, wfn, accuracy)
+      call ceh_singlepoint(ctx, calc, mol, error, wfn, accuracy)
 
       do i = 1, mol%nat
          call check(error, wfn%qat(i,1), ref(i), thr=1e-6_wp)
@@ -1250,12 +1250,12 @@ contains
 
       call get_structure(mol, "MB16-43", "01")
       mol%charge = 2.0_wp
-      call new_ceh_calculator(calc, mol)
+      call new_ceh_calculator(calc, mol, error)
       call new_wavefunction(wfn, mol%nat, calc%bas%nsh, calc%bas%nao, 1, kt)
       cont = electric_field(efield)
       call calc%push_back(cont)
       ctx%verbosity = 0
-      call ceh_guess(ctx, calc, mol, error, wfn, accuracy)
+      call ceh_singlepoint(ctx, calc, mol, error, wfn, accuracy)
 
       do i = 1, mol%nat
          call check(error, wfn%qat(i,1), ref(i), thr=5e-6_wp, message="Calculated charge&
@@ -1283,10 +1283,10 @@ contains
 
       call get_structure(mol, "MB16-43", "01")
 
-      call new_ceh_calculator(calc, mol)
+      call new_ceh_calculator(calc, mol, error)
       call new_wavefunction(wfn, mol%nat, calc%bas%nsh, calc%bas%nao, 1, kt)
       ctx%verbosity = 0
-      call ceh_guess(ctx, calc, mol, error, wfn, accuracy)
+      call ceh_singlepoint(ctx, calc, mol, error, wfn, accuracy)
       tmp = 0.0_wp
       dipole = 0.0_wp
       call gemv(mol%xyz, wfn%qat(:, 1), tmp)
@@ -1324,14 +1324,14 @@ contains
       efield = 0.0_wp
       efield(2) = 0.2_wp
 
-      call new_ceh_calculator(calc, mol)
+      call new_ceh_calculator(calc, mol, error)
       call new_wavefunction(wfn, mol%nat, calc%bas%nsh, calc%bas%nao, 1, kt)
 
       cont = electric_field(efield)
       call calc%push_back(cont)
 
       ctx%verbosity = 0
-      call ceh_guess(ctx, calc, mol, error, wfn, accuracy)
+      call ceh_singlepoint(ctx, calc, mol, error, wfn, accuracy)
       tmp = 0.0_wp
       dipole = 0.0_wp
       call gemv(mol%xyz, wfn%qat(:, 1), tmp)
@@ -1375,11 +1375,11 @@ contains
       call new(mol1, num, xyz)
       efield = 0.0_wp
       efield(1) = -0.1_wp
-      call new_ceh_calculator(calc1, mol1)
+      call new_ceh_calculator(calc1, mol1, error)
       call new_wavefunction(wfn1, mol1%nat, calc1%bas%nsh, calc1%bas%nao, 1, kt)
       cont1 = electric_field(efield)
       call calc1%push_back(cont1)
-      call ceh_guess(ctx, calc1, mol1, error, wfn1, accuracy)
+      call ceh_singlepoint(ctx, calc1, mol1, error, wfn1, accuracy)
       tmp = 0.0_wp
       dip1 = 0.0_wp
       call gemv(mol1%xyz, wfn1%qat(:, 1), tmp)
@@ -1387,11 +1387,11 @@ contains
 
       xyz(1, :) = xyz(1, :) - 1.0_wp
       call new(mol2, num, xyz)
-      call new_ceh_calculator(calc2, mol2)
+      call new_ceh_calculator(calc2, mol2, error)
       call new_wavefunction(wfn2, mol2%nat, calc2%bas%nsh, calc2%bas%nao, 1, kt)
       cont2 = electric_field(efield)
       call calc2%push_back(cont2)
-      call ceh_guess(ctx, calc2, mol2, error, wfn2, accuracy)
+      call ceh_singlepoint(ctx, calc2, mol2, error, wfn2, accuracy)
       tmp = 0.0_wp
       dip2 = 0.0_wp
       call gemv(mol2%xyz, wfn2%qat(:, 1), tmp)

--- a/test/unit/test_gfn1_xtb.f90
+++ b/test/unit/test_gfn1_xtb.f90
@@ -183,7 +183,7 @@ subroutine test_e_pse(error)
    do izp = 1, 86
       if (izp == 25) cycle
       call new(mol, [izp], xyz, uhf=uhf(izp))
-      call new_gfn1_calculator(calc, mol)
+      call new_gfn1_calculator(calc, mol, error)
       call new_wavefunction(wfn, mol%nat, calc%bas%nsh, calc%bas%nao, 1, kt)
 
       energy = 0.0_wp
@@ -254,7 +254,7 @@ subroutine test_e_pse_cation(error)
    do izp = 1, 86
       if (izp == 79) cycle  ! SCF does not converge for gold
       call new(mol, [izp], xyz, uhf=uhf(izp), charge=1.0_wp)
-      call new_gfn1_calculator(calc, mol)
+      call new_gfn1_calculator(calc, mol, error)
       call new_wavefunction(wfn, mol%nat, calc%bas%nsh, calc%bas%nao, 1, kt)
 
       energy = 0.0_wp
@@ -326,7 +326,7 @@ subroutine test_e_pse_anion(error)
       if (izp == 2) cycle  ! Helium doesn't have enough orbitals for negative charge
       if (any(izp == [21, 22, 23, 25, 43, 57, 58, 59])) cycle  ! not converging
       call new(mol, [izp], xyz, uhf=uhf(izp), charge=-1.0_wp)
-      call new_gfn1_calculator(calc, mol)
+      call new_gfn1_calculator(calc, mol, error)
       call new_wavefunction(wfn, mol%nat, calc%bas%nsh, calc%bas%nao, 1, kt)
 
       energy = 0.0_wp
@@ -358,7 +358,7 @@ subroutine test_e_mb01(error)
 
    energy = 0.0_wp
 
-   call new_gfn1_calculator(calc, mol)
+   call new_gfn1_calculator(calc, mol, error)
    call new_wavefunction(wfn, mol%nat, calc%bas%nsh, calc%bas%nao, 1, kt)
    call xtb_singlepoint(ctx, mol, calc, wfn, acc, energy, verbosity=0)
 
@@ -405,7 +405,7 @@ subroutine test_g_mb02(error)
    gradient(:, :) = 0.0_wp
    sigma(:, :) = 0.0_wp
 
-   call new_gfn1_calculator(calc, mol)
+   call new_gfn1_calculator(calc, mol, error)
    call new_wavefunction(wfn, mol%nat, calc%bas%nsh, calc%bas%nao, 1, kt)
    call xtb_singlepoint(ctx, mol, calc, wfn, acc, energy, gradient, sigma, 0)
 
@@ -440,7 +440,7 @@ subroutine test_s_mb03(error)
    gradient(:, :) = 0.0_wp
    sigma(:, :) = 0.0_wp
 
-   call new_gfn1_calculator(calc, mol)
+   call new_gfn1_calculator(calc, mol, error)
    call new_wavefunction(wfn, mol%nat, calc%bas%nsh, calc%bas%nao, 1, kt)
    call xtb_singlepoint(ctx, mol, calc, wfn, acc, energy, gradient, sigma, 0)
 
@@ -475,7 +475,7 @@ subroutine test_error_mb01(error)
 
    energy = 0.0_wp
 
-   call new_gfn1_calculator(calc, mol)
+   call new_gfn1_calculator(calc, mol, error)
    call new_wavefunction(wfn, mol%nat, calc%bas%nsh, calc%bas%nao, 1, kt)
    call xtb_singlepoint(ctx, mol, calc, wfn, acc, energy, verbosity=0)
 

--- a/test/unit/test_gfn2_xtb.f90
+++ b/test/unit/test_gfn2_xtb.f90
@@ -110,7 +110,7 @@ subroutine test_e_pse(error)
 
    do izp = 1, 86
       call new(mol, [izp], xyz, uhf=uhf(izp))
-      call new_gfn2_calculator(calc, mol)
+      call new_gfn2_calculator(calc, mol, error)
       call new_wavefunction(wfn, mol%nat, calc%bas%nsh, calc%bas%nao, 1, kt)
 
       energy = 0.0_wp
@@ -181,7 +181,7 @@ subroutine test_e_pse_cation(error)
    do izp = 1, 86
       if (any(izp == [4, 5, 6])) cycle  ! not converging
       call new(mol, [izp], xyz, uhf=uhf(izp), charge=1.0_wp)
-      call new_gfn2_calculator(calc, mol)
+      call new_gfn2_calculator(calc, mol, error)
       call new_wavefunction(wfn, mol%nat, calc%bas%nsh, calc%bas%nao, 1, kt)
 
       energy = 0.0_wp
@@ -252,7 +252,7 @@ subroutine test_e_pse_anion(error)
    do izp = 1, 86
       if (izp == 24) cycle  ! not converging
       call new(mol, [izp], xyz, uhf=uhf(izp), charge=-1.0_wp)
-      call new_gfn2_calculator(calc, mol)
+      call new_gfn2_calculator(calc, mol, error)
       call new_wavefunction(wfn, mol%nat, calc%bas%nsh, calc%bas%nao, 1, kt)
 
       energy = 0.0_wp
@@ -284,7 +284,7 @@ subroutine test_e_mb01(error)
 
    energy = 0.0_wp
 
-   call new_gfn2_calculator(calc, mol)
+   call new_gfn2_calculator(calc, mol, error)
    call new_wavefunction(wfn, mol%nat, calc%bas%nsh, calc%bas%nao, 1, kt)
    call xtb_singlepoint(ctx, mol, calc, wfn, acc, energy, verbosity=0)
 
@@ -330,7 +330,7 @@ subroutine test_g_mb02(error)
    gradient(:, :) = 0.0_wp
    sigma(:, :) = 0.0_wp
 
-   call new_gfn2_calculator(calc, mol)
+   call new_gfn2_calculator(calc, mol, error)
    call new_wavefunction(wfn, mol%nat, calc%bas%nsh, calc%bas%nao, 1, kt)
    call xtb_singlepoint(ctx, mol, calc, wfn, acc, energy, gradient, sigma, 0)
 
@@ -367,7 +367,7 @@ subroutine test_convergence(error)
 
    energy = 0.0_wp
 
-   call new_gfn2_calculator(calc, mol)
+   call new_gfn2_calculator(calc, mol, error)
    call new_wavefunction(wfn, mol%nat, calc%bas%nsh, calc%bas%nao, 1, kt)
    call eeq_guess(mol, calc, wfn)
    call xtb_singlepoint(ctx, mol, calc, wfn, acc, energy, verbosity=0)

--- a/test/unit/test_ipea1_xtb.f90
+++ b/test/unit/test_ipea1_xtb.f90
@@ -181,7 +181,7 @@ subroutine test_e_pse(error)
    do izp = 1, 86
       if (any(izp == [21, 22, 24, 26, 40, 73])) cycle ! SCF does not converge
       call new(mol, [izp], xyz, uhf=uhf(izp))
-      call new_ipea1_calculator(calc, mol)
+      call new_ipea1_calculator(calc, mol, error)
       call new_wavefunction(wfn, mol%nat, calc%bas%nsh, calc%bas%nao, 1, kt)
 
       energy = 0.0_wp
@@ -252,7 +252,7 @@ subroutine test_e_pse_cation(error)
    do izp = 1, 86
       if (any(izp == [22, 25, 79])) cycle  ! SCF does not converge
       call new(mol, [izp], xyz, uhf=uhf(izp), charge=1.0_wp)
-      call new_ipea1_calculator(calc, mol)
+      call new_ipea1_calculator(calc, mol, error)
       call new_wavefunction(wfn, mol%nat, calc%bas%nsh, calc%bas%nao, 1, kt)
 
       energy = 0.0_wp
@@ -324,7 +324,7 @@ subroutine test_e_pse_anion(error)
       if (izp == 2) cycle  ! Helium doesn't have enough orbitals for negative charge
       if (any(izp == [21, 22, 25, 40, 43, 57, 58, 59, 77, 82])) cycle  ! not converging
       call new(mol, [izp], xyz, uhf=uhf(izp), charge=-1.0_wp)
-      call new_ipea1_calculator(calc, mol)
+      call new_ipea1_calculator(calc, mol, error)
       call new_wavefunction(wfn, mol%nat, calc%bas%nsh, calc%bas%nao, 1, kt)
 
       energy = 0.0_wp
@@ -356,7 +356,7 @@ subroutine test_e_mb01(error)
 
    energy = 0.0_wp
 
-   call new_ipea1_calculator(calc, mol)
+   call new_ipea1_calculator(calc, mol, error)
    call new_wavefunction(wfn, mol%nat, calc%bas%nsh, calc%bas%nao, 1, kt)
    call xtb_singlepoint(ctx, mol, calc, wfn, acc, energy, verbosity=0)
 
@@ -402,7 +402,7 @@ subroutine test_g_mb02(error)
    gradient(:, :) = 0.0_wp
    sigma(:, :) = 0.0_wp
 
-   call new_ipea1_calculator(calc, mol)
+   call new_ipea1_calculator(calc, mol, error)
    call new_wavefunction(wfn, mol%nat, calc%bas%nsh, calc%bas%nao, 1, kt)
    call xtb_singlepoint(ctx, mol, calc, wfn, acc, energy, gradient, sigma, 0)
 
@@ -437,7 +437,7 @@ subroutine test_s_mb03(error)
    gradient(:, :) = 0.0_wp
    sigma(:, :) = 0.0_wp
 
-   call new_ipea1_calculator(calc, mol)
+   call new_ipea1_calculator(calc, mol, error)
    call new_wavefunction(wfn, mol%nat, calc%bas%nsh, calc%bas%nao, 1, kt)
    call xtb_singlepoint(ctx, mol, calc, wfn, acc, energy, gradient, sigma, 0)
 

--- a/test/unit/test_post_processing.f90
+++ b/test/unit/test_post_processing.f90
@@ -60,7 +60,7 @@ subroutine test_h2_wbo(error)
       & shape(xyz))
    
    call new(mol, atoms, xyz, charge=+1.0_wp, uhf=1)
-   call new_gfn2_calculator(calc, mol)
+   call new_gfn2_calculator(calc, mol, error)
    call new_wavefunction(wfn, mol%nat, calc%bas%nsh, calc%bas%nao, 1, kt)
    wbo_label = "bond-orders"
    call add_post_processing(pproc, wbo_label, error)
@@ -156,7 +156,7 @@ subroutine test_timer_print(error)
       & shape(xyz))
    
    call new(mol, atoms, xyz, charge=+1.0_wp, uhf=1)
-   call new_gfn2_calculator(calc, mol)
+   call new_gfn2_calculator(calc, mol, error)
    call new_wavefunction(wfn, mol%nat, calc%bas%nsh, calc%bas%nao, 1, kt)
    wbo_label = "bond-orders"
    call add_post_processing(pproc, wbo_label, error)

--- a/test/unit/test_spin.f90
+++ b/test/unit/test_spin.f90
@@ -83,7 +83,7 @@ subroutine test_e_p10(error)
    call rse43_p10(mol)
    energy = 0.0_wp
 
-   call new_gfn2_calculator(calc, mol)
+   call new_gfn2_calculator(calc, mol, error)
    call new_wavefunction(wfn, mol%nat, calc%bas%nsh, calc%bas%nao, 2, kt)
 
    block
@@ -127,7 +127,7 @@ subroutine test_e_crcp2(error)
    allocate(gradient(3, mol%nat), sigma(3, 3))
    energy = 0.0_wp
 
-   call new_gfn1_calculator(calc, mol)
+   call new_gfn1_calculator(calc, mol, error)
    call new_wavefunction(wfn, mol%nat, calc%bas%nsh, calc%bas%nao, 2, kt)
 
    block
@@ -192,7 +192,7 @@ subroutine test_g_p10(error)
    gradient(:, :) = 0.0_wp
    sigma(:, :) = 0.0_wp
 
-   call new_gfn1_calculator(calc, mol)
+   call new_gfn1_calculator(calc, mol, error)
    call new_wavefunction(wfn, mol%nat, calc%bas%nsh, calc%bas%nao, 2, kt)
 
    block
@@ -256,7 +256,7 @@ subroutine test_g_crcp2(error)
    gradient(:, :) = 0.0_wp
    sigma(:, :) = 0.0_wp
 
-   call new_gfn2_calculator(calc, mol)
+   call new_gfn2_calculator(calc, mol, error)
    call new_wavefunction(wfn, mol%nat, calc%bas%nsh, calc%bas%nao, 2, kt)
 
    block

--- a/test/unit/test_xtb_external.f90
+++ b/test/unit/test_xtb_external.f90
@@ -83,7 +83,7 @@ subroutine test_e_mb01(error)
    call get_structure(mol, "MB16-43", "01")
    energy = 0.0_wp
 
-   call new_gfn1_calculator(calc, mol)
+   call new_gfn1_calculator(calc, mol, error)
    call new_wavefunction(wfn, mol%nat, calc%bas%nsh, calc%bas%nao, 1, kt)
 
    cont = electric_field([-2.0_wp, 0.0_wp, 0.0_wp]*vatoau)
@@ -120,7 +120,7 @@ subroutine test_e_mb02(error)
    allocate(gradient(3, mol%nat), sigma(3, 3))
    energy = 0.0_wp
 
-   call new_gfn2_calculator(calc, mol)
+   call new_gfn2_calculator(calc, mol, error)
    call new_wavefunction(wfn, mol%nat, calc%bas%nsh, calc%bas%nao, 1, kt)
 
    cont = electric_field([0.0_wp, sqrt(2.0_wp), -sqrt(2.0_wp)]*vatoau)
@@ -157,7 +157,7 @@ subroutine test_d_mb03(error)
    energy = 0.0_wp
    efield(:) = 0.0_wp
 
-   call new_gfn1_calculator(calc, mol)
+   call new_gfn1_calculator(calc, mol, error)
    call new_wavefunction(wfn0, mol%nat, calc%bas%nsh, calc%bas%nao, 1, kt)
 
    cont = electric_field(efield)
@@ -215,7 +215,7 @@ subroutine test_d_mb04(error)
    energy = 0.0_wp
    efield(:) = 0.0_wp
 
-   call new_gfn2_calculator(calc, mol)
+   call new_gfn2_calculator(calc, mol, error)
    call new_wavefunction(wfn0, mol%nat, calc%bas%nsh, calc%bas%nao, 1, kt)
 
    cont = electric_field(efield)
@@ -292,7 +292,7 @@ subroutine test_g_mb05(error)
    gradient(:, :) = 0.0_wp
    sigma(:, :) = 0.0_wp
 
-   call new_gfn2_calculator(calc, mol)
+   call new_gfn2_calculator(calc, mol, error)
    call new_wavefunction(wfn, mol%nat, calc%bas%nsh, calc%bas%nao, 1, kt)
 
    cont = empty_interaction()
@@ -344,7 +344,7 @@ subroutine test_g_mb06(error)
    gradient(:, :) = 0.0_wp
    sigma(:, :) = 0.0_wp
 
-   call new_gfn2_calculator(calc, mol)
+   call new_gfn2_calculator(calc, mol, error)
    call new_wavefunction(wfn, mol%nat, calc%bas%nsh, calc%bas%nao, 1, kt)
 
    cont = empty_interaction()

--- a/test/unit/test_xtb_param.f90
+++ b/test/unit/test_xtb_param.f90
@@ -391,17 +391,18 @@ subroutine export_gen_param(method, param)
 end subroutine export_gen_param
 
 
-subroutine new_gen_calculator(calc, method, mol)
+subroutine new_gen_calculator(calc, method, mol, error)
    type(xtb_calculator), intent(out) :: calc
    character(len=*), intent(in) :: method
    type(structure_type), intent(in) :: mol
+   type(error_type), allocatable, intent(out) :: error
    select case(method)
    case("gfn1")
-      call new_gfn1_calculator(calc, mol)
+      call new_gfn1_calculator(calc, mol, error)
    case("gfn2")
-      call new_gfn2_calculator(calc, mol)
+      call new_gfn2_calculator(calc, mol, error)
    case("ipea1")
-      call new_ipea1_calculator(calc, mol)
+      call new_ipea1_calculator(calc, mol, error)
    end select
 end subroutine new_gen_calculator
 
@@ -427,7 +428,7 @@ subroutine test_gen(mol, method, error)
    call new_wavefunction(wfn, mol%nat, calc%bas%nsh, calc%bas%nao, 1, kt)
    call xtb_singlepoint(ctx, mol, calc, wfn, acc, energy1, verbosity=0)
 
-   call new_gen_calculator(calc, method, mol)
+   call new_gen_calculator(calc, method, mol, error)
 
    call new_wavefunction(wfn, mol%nat, calc%bas%nsh, calc%bas%nao, 1, kt)
    call xtb_singlepoint(ctx, mol, calc, wfn, acc, energy2, verbosity=0)


### PR DESCRIPTION
# Fix broken guess for AC's

Calculation of atomic charges with CEH via `tblite guess --method ceh` was broken as a GFN2 calculator was set up. As GFN2 does not have shells for Z>86, a memory issue popped up.
In the present branch, this is resolved via having only a CEH calculator, also for projection of the other guess types on the wavefunction (template wavefunction is now not of GFN2 type but of CEH type). Don't see any problems with this, if you see some, let me know 🙌🏻

As a side effect, the code gets much cleaner and we're saving some lines.